### PR TITLE
Force usage of TwitterKit5 (#6)

### DIFF
--- a/react-native-login-twitter.podspec
+++ b/react-native-login-twitter.podspec
@@ -15,5 +15,5 @@ Pod::Spec.new do |s|
   s.source_files  = "ios/*.{h,m}"
 
   s.dependency "React"
-  s.dependency "TwitterKit"
+  s.dependency "TwitterKit5"
 end


### PR DESCRIPTION
Force usage of TwitterKit5 because TwitterKit 3.1.2 will be used by default, which causes a UIWebView deprecation warning when submitting a build to AppStore.